### PR TITLE
fix: Add getUserDataFromWebsite

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,13 @@ class DummycliskContentScript extends ContentScript {
     return { event, timeout, url }
   }
 
+  async getUserDataFromWebsite() {
+    this.log('info', '🤖 getUserDataFromWebsite')
+    return {
+      sourceAccountIdentifier: 'defaultDummyCliskAccountIdentifier'
+    }
+  }
+
   async fetch() {
     this.log('debug', 'Debug level, Starting fetch')
     this.log('info', 'Info level, Starting fetch')


### PR DESCRIPTION
This method is now mandatory to get a sourceAccountIdentifier for
context
